### PR TITLE
APP-633: Returning HTTP 415 when the payload content-type is not supported

### DIFF
--- a/src/main/java/org/symphonyoss/integration/webhook/salesforce/SalesforceWebHookIntegration.java
+++ b/src/main/java/org/symphonyoss/integration/webhook/salesforce/SalesforceWebHookIntegration.java
@@ -31,14 +31,14 @@ import org.symphonyoss.integration.webhook.WebHookPayload;
 import org.symphonyoss.integration.webhook.exception.WebHookParseException;
 import org.symphonyoss.integration.webhook.salesforce.parser.SalesforceParser;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import javax.annotation.PostConstruct;
 import javax.ws.rs.core.MediaType;
 import javax.xml.bind.JAXBException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Created by rsanchez on 31/08/16.
@@ -151,4 +151,13 @@ public class SalesforceWebHookIntegration extends WebHookIntegration {
     return super.buildMessageML(messageML, OPPORTUNITY_NOTIFICATION_JSON);
   }
 
+  /**
+   * @see WebHookIntegration#getSupportedContentTypes()
+   */
+  @Override
+  public List<MediaType> getSupportedContentTypes() {
+    List<MediaType> supportedContentTypes = new ArrayList<>();
+    supportedContentTypes.add(MediaType.WILDCARD_TYPE);
+    return supportedContentTypes;
+  }
 }


### PR DESCRIPTION
This integration now provides a list of acceptable payload types. In this case, no one has been provided, that's why it's using MediaType.WILDCARD_TYPE. It could also return an empty/null List, same behavior.